### PR TITLE
feat(admin-service,auth-service)!: require email on user registration…

### DIFF
--- a/admin-service/src/main/java/com/hospital/admin_service/dto/doctor/DoctorRead.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/dto/doctor/DoctorRead.java
@@ -12,6 +12,12 @@ public record DoctorRead(
         Long userId,
         Long specialtyId,
         String specialtyName,
+
+        String username,
+        String firstName,
+        String lastName,
+        String gender,
+
         Instant createdAt,
         Instant updatedAt
 ) {}

--- a/admin-service/src/main/java/com/hospital/admin_service/external/feign/AuthFeignClient.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/external/feign/AuthFeignClient.java
@@ -22,7 +22,7 @@ public interface AuthFeignClient {
     @Retry(name = "authService")
     ResponseEntity<UserResponse> register(@RequestBody CreateUserForDoctorRequest body);
 
-    @GetMapping("/users/me/{id}")
+    @GetMapping("/users/{id}")
     @CircuitBreaker(name = "authService")
     @Retry(name = "authService")
     ResponseEntity<UserResponse> getUserById(@PathVariable("id") Long id);

--- a/admin-service/src/main/java/com/hospital/admin_service/mapper/DoctorMapper.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/mapper/DoctorMapper.java
@@ -16,6 +16,11 @@ public interface DoctorMapper {
             @Mapping(target = "userId",        source = "userId"),
             @Mapping(target = "specialtyId",   source = "specialty.id"),
             @Mapping(target = "specialtyName", source = "specialty.name"),
+            // Estos 4 se enriquecen fuera del mapper (servicio/assembler)
+            @Mapping(target = "username",  ignore = true),
+            @Mapping(target = "firstName", ignore = true),
+            @Mapping(target = "lastName",  ignore = true),
+            @Mapping(target = "gender",    ignore = true),
             @Mapping(target = "createdAt",     source = "createdAt"),
             @Mapping(target = "updatedAt",     source = "updatedAt")
     })

--- a/admin-service/src/main/java/com/hospital/admin_service/rest/DoctorController.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/rest/DoctorController.java
@@ -38,14 +38,13 @@ public class DoctorController {
     @GetMapping
     public Page<DoctorRead> list(@RequestParam(defaultValue = "false") boolean includeDeleted,
                                  Pageable pageable) {
-        return readService.findAllPage(includeDeleted, pageable).map(mapper::toRead);
+        return readService.findAllPage(includeDeleted, pageable);
     }
 
     @RequireRole("ADMIN")
     @GetMapping("/all")
     public List<DoctorRead> listAll(@RequestParam(defaultValue = "false") boolean includeDeleted) {
         return readService.findAllEntities(includeDeleted).stream()
-                .map(mapper::toRead)
                 .toList();
     }
 
@@ -53,19 +52,19 @@ public class DoctorController {
     @GetMapping("/{id}")
     public DoctorRead getOne(@PathVariable Long id,
                              @RequestParam(defaultValue = "false") boolean includeDeleted) {
-        return mapper.toRead(readService.findEntityById(id, includeDeleted));
+        return readService.findEntityById(id, includeDeleted);
     }
 
     @RequireRole("ADMIN")
     @GetMapping("/by-user/{userId}")
     public DoctorRead getByUserId(@PathVariable Long userId) {
-        return mapper.toRead(readService.findByUserId(userId));
+        return readService.findByUserId(userId);
     }
 
     @RequireRole("ADMIN")
     @GetMapping("/by-specialty/{specialtyId}")
     public Page<DoctorRead> listBySpecialty(@PathVariable Long specialtyId, Pageable pageable) {
-        return readService.findBySpecialty(specialtyId, pageable).map(mapper::toRead);
+        return readService.findBySpecialty(specialtyId, pageable);
     }
 
     /* =========================

--- a/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorReadAssembler.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorReadAssembler.java
@@ -1,0 +1,43 @@
+package com.hospital.admin_service.service.doctor;
+
+import com.hospital.admin_service.dto.doctor.DoctorRead;
+import com.hospital.admin_service.external.dto.user.UserResponse;
+import com.hospital.admin_service.external.port.IAuthUserClient;
+import com.hospital.admin_service.mapper.DoctorMapper;
+import com.hospital.admin_service.model.Doctor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.data.domain.Page;
+
+@Component
+@RequiredArgsConstructor
+public class DoctorReadAssembler {
+
+    private final DoctorMapper mapper;
+    private final IAuthUserClient authClient;
+
+    public DoctorRead toRead(Doctor entity) {
+        DoctorRead base = mapper.toRead(entity);
+        if (entity.getUserId() == null) return base;
+
+        UserResponse user = authClient.getUserById(entity.getUserId());
+        if (user == null) return base;
+        return new DoctorRead(
+                base.id(),
+                base.version(),
+                base.userId(),
+                base.specialtyId(),
+                base.specialtyName(),
+                user.username(),
+                user.firstName(),
+                user.lastName(),
+                user.gender(),
+                base.createdAt(),
+                base.updatedAt()
+        );
+    }
+
+    public Page<DoctorRead> toReadPage(Page<Doctor> page) {
+        return page.map(this::toRead);
+    }
+}

--- a/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorReadService.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorReadService.java
@@ -1,6 +1,6 @@
 package com.hospital.admin_service.service.doctor;
 
-import com.hospital.admin_service.model.Doctor;
+import com.hospital.admin_service.dto.doctor.DoctorRead;
 import com.hospital.admin_service.repo.DoctorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,31 +18,32 @@ import java.util.List;
 public class DoctorReadService {
 
     private final DoctorRepository repository;
+    private final DoctorReadAssembler assembler;
 
-    public List<Doctor> findAllEntities(boolean includeDeleted) {
-        return includeDeleted ? repository.findAllIncludingDeleted() : repository.findAll();
+    public List<DoctorRead> findAllEntities(boolean includeDeleted) {
+        var list = includeDeleted ? repository.findAllIncludingDeleted() : repository.findAll();
+        return list.stream().map(assembler::toRead).toList();
     }
 
-    public Page<Doctor> findAllPage(boolean includeDeleted, Pageable pageable) {
-        return includeDeleted ? repository.findAllIncludingDeletedPage(pageable)
-                : repository.findAll(pageable);
+    public Page<DoctorRead> findAllPage(boolean includeDeleted, Pageable pageable) {
+        var page = includeDeleted ? repository.findAllIncludingDeletedPage(pageable) : repository.findAll(pageable);
+        return assembler.toReadPage(page);
     }
 
-    public Doctor findEntityById(Long id, boolean includeDeleted) {
-        return (includeDeleted ? repository.findByIdIncludingDeleted(id) : repository.findById(id))
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "El Doctor no existe."
-                ));
+    public DoctorRead findEntityById(Long id, boolean includeDeleted) {
+        var entity = (includeDeleted ? repository.findByIdIncludingDeleted(id) : repository.findById(id))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "El Doctor no existe."));
+        return assembler.toRead(entity);
     }
 
-    public Doctor findByUserId(Long userId) {
-        return repository.findByUserId(userId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "No existe Doctor activo para el usuario dado."
-                ));
+    public DoctorRead findByUserId(Long userId) {
+        var entity = repository.findByUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No existe Doctor activo para el usuario dado."));
+        return assembler.toRead(entity);
     }
 
-    public Page<Doctor> findBySpecialty(Long specialtyId, Pageable pageable) {
-        return repository.findAllBySpecialty_Id(specialtyId, pageable);
+    public Page<DoctorRead> findBySpecialty(Long specialtyId, Pageable pageable) {
+        return assembler.toReadPage(repository.findAllBySpecialty_Id(specialtyId, pageable));
     }
 }
+

--- a/auth-service/src/main/java/com/hospital/rests/UserAndAuthController.java
+++ b/auth-service/src/main/java/com/hospital/rests/UserAndAuthController.java
@@ -26,6 +26,12 @@ public class UserAndAuthController {
         return ResponseEntity.ok(mapper.toUserResponse(user));
     }
 
+    @GetMapping("/users/{id}")
+    public ResponseEntity<UserResponse> getUserById(@PathVariable Long id) {
+        User user = service.findUserById(id);
+        return ResponseEntity.ok(mapper.toUserResponse(user));
+    }
+
     @GetMapping("/users/by-center/{id}")
     public ResponseEntity<UserResponse> getUserByCenterId(
             @PathVariable Long id,


### PR DESCRIPTION
…; enrich DoctorRead; fix joint doctor+user creation

- Enforce `email` as a required field when creating/registering users
- Update AuthFeignClient to pass `email` to auth-service
- Enrich DoctorRead response with extra fields: userId, username, firstName, lastName, gender, specialtyId, specialtyName, createdAt, updatedAt
- Add/adjust DoctorReadAssembler & DoctorReadService to compose the enriched payload
- Fix doctor registration flow when creating doctor + user together (transactional consistency, error mapping, rollback on failure)
- Minor adjustments in DoctorController and DoctorMapper

BREAKING CHANGE: User registration now requires `email`. Clients must include `email` in `/admin/doctors/register` (and related flows) or requests will fail with validation errors.