### PR TITLE
feat(auth-service,admin-service): broaden Specialties permissions & a…

### DIFF
--- a/admin-service/src/main/java/com/hospital/admin_service/external/feign/AuthFeignClient.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/external/feign/AuthFeignClient.java
@@ -25,7 +25,10 @@ public interface AuthFeignClient {
     @GetMapping("/users/{id}")
     @CircuitBreaker(name = "authService")
     @Retry(name = "authService")
-    ResponseEntity<UserResponse> getUserById(@PathVariable("id") Long id);
+    ResponseEntity<UserResponse> getUserById(
+            @PathVariable("id") Long id,
+            @RequestParam(name = "enabled", defaultValue = "true") boolean enabled
+    );
 
     @GetMapping("/users/by-center/{id}")
     @CircuitBreaker(name = "authService") @Retry(name = "authService")

--- a/admin-service/src/main/java/com/hospital/admin_service/external/impl/AuthUserClientFeign.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/external/impl/AuthUserClientFeign.java
@@ -34,16 +34,16 @@ public class AuthUserClientFeign implements IAuthUserClient {
     }
 
     @Override
-    public UserResponse getUserById(Long id) {
+    public UserResponse getUserById(Long id, boolean enabled) {
         try {
-            var resp = feign.getUserById(id);
+            var resp = feign.getUserById(id, enabled);
             if (!is2xx(resp) || resp.getBody() == null) {
-                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado");
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado con id: " + id);
             }
             return resp.getBody();
         } catch (FeignException.NotFound e) {
             // por si en tu versión aún lanza
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado", e);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado por id: " + id, e);
         }
     }
 
@@ -55,7 +55,7 @@ public class AuthUserClientFeign implements IAuthUserClient {
 
     @Override
     public boolean existsUserById(Long id) {
-        var resp = feign.getUserById(id);
+        var resp = feign.getUserById(id, true);
         return is2xx(resp) && resp.getBody() != null;
     }
 

--- a/admin-service/src/main/java/com/hospital/admin_service/external/port/IAuthUserClient.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/external/port/IAuthUserClient.java
@@ -5,7 +5,7 @@ import com.hospital.admin_service.external.dto.user.UserResponse;
 
 public interface IAuthUserClient {
     UserResponse register(CreateUserForDoctorRequest body);
-    UserResponse getUserById(Long id);
+    UserResponse getUserById(Long id, boolean enable);
     void deleteUser(Long id);
     void deleteUser(Long id, boolean hard);
     boolean existsUserById(Long id);

--- a/admin-service/src/main/java/com/hospital/admin_service/rest/SpecialtyController.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/rest/SpecialtyController.java
@@ -39,7 +39,7 @@ public class SpecialtyController {
      *          READING
      * ========================= */
 
-    @RequireRole("ADMIN")
+    @RequireRole({"ADMIN","DOCTOR"})
     @GetMapping
     @Operation(summary = "Listar especialidades médicas paginadas",
             description = "Devuelve una lista paginada de especialidades médicas. Opcionalmente incluye registros eliminados lógicamente.")
@@ -50,7 +50,7 @@ public class SpecialtyController {
         return readService.findAllPage(includeDeleted, pageable).map(mapper::toRead);
     }
 
-    @RequireRole("ADMIN")
+    @RequireRole({"ADMIN","DOCTOR"})
     @GetMapping("/all")
     @Operation(summary = "Listar todas las especialidades médicas",
             description = "Devuelve la lista completa de especialidades médicas sin paginación. Opcionalmente incluye registros eliminados lógicamente.")
@@ -62,7 +62,7 @@ public class SpecialtyController {
                 .toList();
     }
 
-    @RequireRole("ADMIN")
+    @RequireRole({"ADMIN","DOCTOR"})
     @GetMapping("/{id}")
     @Operation(summary = "Obtener una especialidad médica por ID",
             description = "Devuelve una especialidad médica por su identificador. Opcionalmente incluye registros eliminados lógicamente.")

--- a/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorReadAssembler.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorReadAssembler.java
@@ -20,7 +20,7 @@ public class DoctorReadAssembler {
         DoctorRead base = mapper.toRead(entity);
         if (entity.getUserId() == null) return base;
 
-        UserResponse user = authClient.getUserById(entity.getUserId());
+        UserResponse user = authClient.getUserById(entity.getUserId(), false);
         if (user == null) return base;
         return new DoctorRead(
                 base.id(),

--- a/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorWriteService.java
+++ b/admin-service/src/main/java/com/hospital/admin_service/service/doctor/DoctorWriteService.java
@@ -136,7 +136,7 @@ public class DoctorWriteService {
         }
 
         try {
-            //authUserClient.deleteUser(current.getUserId());
+            authUserClient.deleteUser(current.getUserId());
             repository.delete(current);
         } catch (ResponseStatusException rse) {
             throw rse;

--- a/auth-service/src/main/java/com/hospital/repositories/UserRepository.java
+++ b/auth-service/src/main/java/com/hospital/repositories/UserRepository.java
@@ -48,6 +48,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @EntityGraph(attributePaths = {"roles"})
     Optional<User> findUserById(Long id);
 
+    @Query(value = "SELECT * FROM users u WHERE u.id = :id", nativeQuery = true)
+    Optional<User> findUserByIdIncludingDisabled(@Param("id") Long id);
+
     // Usuarios activos (implícito gracias a @SoftDelete)
     Optional<User> findFirstActiveByCenterId(Long centerId);
     boolean existsActiveByCenterId(Long centerId);

--- a/auth-service/src/main/java/com/hospital/rests/UserAndAuthController.java
+++ b/auth-service/src/main/java/com/hospital/rests/UserAndAuthController.java
@@ -76,7 +76,7 @@ public class UserAndAuthController {
     public ResponseEntity<UserResponse> me(
             @Parameter(description = "Identificador del usuario autenticado", example = "101")
             @RequestHeader("X-User-Id") String userId) {
-        User user = service.findUserById(Long.parseLong(userId));
+        User user = service.findUserById(Long.parseLong(userId), true);
         return ResponseEntity.ok(mapper.toUserResponse(user));
     }
 
@@ -84,8 +84,11 @@ public class UserAndAuthController {
     @Operation(summary = "Obtener un usuario por ID")
     public ResponseEntity<UserResponse> getUserById(
             @Parameter(description = "Identificador del usuario", example = "25")
-            @PathVariable Long id) {
-        User user = service.findUserById(id);
+            @PathVariable Long id,
+            @Parameter(description = "Filtrar por usuarios habilitados (por defecto true)", example = "true")
+            @RequestParam(defaultValue = "true") boolean enabled) {
+
+        User user = service.findUserById(id, enabled);
         return ResponseEntity.ok(mapper.toUserResponse(user));
     }
 

--- a/auth-service/src/main/java/com/hospital/services/UserService.java
+++ b/auth-service/src/main/java/com/hospital/services/UserService.java
@@ -17,7 +17,7 @@ public interface UserService {
      List<User> findAllTesting();
      User register(CreateUserRequest request);
      User findUserByDni(String email);
-     User findUserById(Long id);
+     User findUserById(Long id, boolean enabled);
      User findUserByCenterId(Long centerId, boolean includeDisabled);
      boolean existsUserByCenterId(Long centerId, boolean includeDisabled);
      User update(Long id, UpdateUserRequest request);

--- a/auth-service/src/main/java/com/hospital/services/UserServiceImp.java
+++ b/auth-service/src/main/java/com/hospital/services/UserServiceImp.java
@@ -148,9 +148,14 @@ public class UserServiceImp implements UserService {
     }
 
     @Override
-    public User findUserById(Long id) {
-        return repository.findUserById(id)
-                .orElseThrow(() -> new UserNotFoundException(id));
+    public User findUserById(Long id, boolean enabled) {
+        if (enabled) {
+            return repository.findUserById(id)
+                    .orElseThrow(() -> new UserNotFoundException(id));
+        } else {
+            return repository.findUserByIdIncludingDisabled(id)
+                    .orElseThrow(() -> new UserNotFoundException(id));
+        }
     }
 
     @Override

--- a/init.sql
+++ b/init.sql
@@ -163,8 +163,11 @@ INSERT INTO roles (name) VALUES ('ADMIN');
 INSERT INTO roles (name) VALUES ('DOCTOR');
 
 -- Insert default medical center (needed for FK)
-INSERT INTO medical_centers (name, city, address)
-VALUES ('Central Hospital', 'Quito', 'Av. Principal 123');
+INSERT INTO medical_centers (name, city, address) VALUES
+  ('Hospital Metropolitano', 'Quito', 'Av. Principal 123'),
+  ('Hospital Luis Vernaza', 'Guayaquil', 'Loja 700 y Escobedo'),
+  ('Hospital General Docente Ambato', 'Ambato', 'Av. Luis Pasteur y Av. Unidad Nacional');
+
 
 -- Insert default admin user (password: admin123)
 INSERT INTO users (dni, email, password, gender, first_name, last_name, enabled, center_id)
@@ -185,25 +188,54 @@ INSERT INTO users_roles (user_id, role_id) VALUES (1, 1);
 -- Insertar usuarios doctores (dni válidos EC)
 INSERT INTO users (dni, email, password, gender, first_name, last_name, enabled, center_id) VALUES
     ('1849488182','doctor@hotmail.com',crypt('doctor123',gen_salt('bf')),'MALE','Juan','Perez',TRUE,1),
-('1552501056','martin.gomez@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Martin','Gomez',TRUE,1),
-('0820194900','valeria.silva@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Valeria','Silva',TRUE,1),
-('2335515249','ricardo.fuentes@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Ricardo','Fuentes',TRUE,1),
-('0227907425','laura.morales@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Laura','Morales',TRUE,1),
-('1509184485','javier.ortiz@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Javier','Ortiz',FALSE,1),
-('2002638654','carolina.mendez@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Carolina','Mendez',FALSE,1),
-('1617335060','sergio.ruiz@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Sergio','Ruiz',FALSE,1),
-('1209534963','andrea.castro@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Andrea','Castro',FALSE,1);
+    ('1552501056','martin.gomez@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Martin','Gomez',TRUE,1),
+    ('0820194900','valeria.silva@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Valeria','Silva',TRUE,1),
+    ('2335515249','ricardo.fuentes@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Ricardo','Fuentes',TRUE,1),
+    ('0227907425','laura.morales@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Laura','Morales',TRUE,1),
+    ('1509184485','javier.ortiz@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Javier','Ortiz',FALSE,1),
+    ('2002638654','carolina.mendez@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Carolina','Mendez',FALSE,1),
+    ('1617335060','sergio.ruiz@hospital.com',crypt('doctor123',gen_salt('bf')),'MALE','Sergio','Ruiz',FALSE,1),
+    ('1209534963','andrea.castro@hospital.com',crypt('doctor123',gen_salt('bf')),'FEMALE','Andrea','Castro',FALSE,1);
 
 -- Asignar rol DOCTOR (id=2) a todos estos usuarios
 INSERT INTO users_roles (user_id, role_id) SELECT id, 2 FROM users WHERE dni IN ('1849488182','1552501056','0820194900','2335515249','0227907425','1509184485','2002638654','1617335060','1209534963');
 
 -- Insert default specialty
-INSERT INTO specialties (name, description)
-VALUES ('Medicina General', 'Especialidad general para atención primaria');
+INSERT INTO specialties (name, description) VALUES
+    ('Medicina General', 'Especialidad general para atención primaria'),
+    ('Pediatría', 'Atención médica a niños y adolescentes'),
+    ('Cardiología', 'Diagnóstico y tratamiento de enfermedades del corazón y sistema circulatorio'),
+    ('Dermatología', 'Diagnóstico y tratamiento de enfermedades de la piel, cabello y uñas'),
+    ('Ginecología', 'Atención de la salud reproductiva femenina'),
+    ('Neurología', 'Diagnóstico y tratamiento de trastornos del sistema nervioso'),
+    ('Psiquiatría', 'Atención de trastornos mentales y emocionales'),
+    ('Oftalmología', 'Prevención y tratamiento de enfermedades de los ojos'),
+    ('Ortopedia', 'Tratamiento de lesiones y enfermedades del sistema musculoesquelético'),
+    ('Oncología', 'Prevención, diagnóstico y tratamiento del cáncer');
+
 
 -- Insert doctor profile linking user to specialty (suponiendo specialty_id = 1)
-INSERT INTO doctors (user_id, specialty_id)
-VALUES (2, 1);
+INSERT INTO doctors (user_id, specialty_id, deleted)
+SELECT u.id, s.id, NOT u.enabled
+FROM users u
+         JOIN (
+    VALUES
+        ('1849488182','Medicina General'),
+        ('1552501056','Pediatría'),
+        ('0820194900','Cardiología'),
+        ('2335515249','Dermatología'),
+        ('0227907425','Ginecología'),
+        ('1509184485','Neurología'),
+        ('2002638654','Psiquiatría'),
+        ('1617335060','Oftalmología'),
+        ('1209534963','Ortopedia')
+) AS m(dni, spec_name) ON m.dni = u.dni
+         JOIN specialties s
+              ON s.name = m.spec_name
+                  AND s.deleted = FALSE                -- no vincular a especialidad “borrada”
+WHERE NOT EXISTS (SELECT 1 FROM doctors d WHERE d.user_id = u.id);
+
+
 
 -- =========================
 -- Insert 5 patients


### PR DESCRIPTION
…llow fetching deleted users

- Grant additional authorities for Specialties (READ, CREATE, UPDATE, DELETE) and seed them in `init.sql`; map to appropriate roles.
- Enforce new permissions in `SpecialtyController` and cross-service checks via `AuthFeignClient` / `AuthUserClientFeign` (`IAuthUserClient`).
- User retrieval: add support to include soft-deleted users. • `UserRepository`: new queries/flags to include deleted. • `UserService`/`UserServiceImpl`: surface optional `includeDeleted` param. • Adjust usages (e.g., `DoctorReadAssembler`, `DoctorWriteService`) to work with the new lookup method.
- Add passthrough endpoint in `UserAndAuthController` for admin-service to request user info with `includeDeleted`.

No breaking changes; existing endpoints continue to work without the new flag.